### PR TITLE
fix: 게임 진행 오류 수정

### DIFF
--- a/src/main/java/bridge/Application.java
+++ b/src/main/java/bridge/Application.java
@@ -7,12 +7,8 @@ import bridge.view.Messages;
 public class Application {
 
     public static void main(String[] args) {
-        try {
-            OutputView.printSystemMessage(Messages.GAME_START_MESSAGE);
-            BridgeGame bridgeGame = new BridgeGame();
-            bridgeGame.startGame();
-        } catch (IllegalArgumentException e) {
-            System.out.println(e.getMessage());
-        }
+        OutputView.printSystemMessage(Messages.GAME_START_MESSAGE);
+        BridgeGame bridgeGame = new BridgeGame();
+        bridgeGame.startGame();
     }
 }

--- a/src/main/java/bridge/BridgeMaker.java
+++ b/src/main/java/bridge/BridgeMaker.java
@@ -17,8 +17,9 @@ public class BridgeMaker {
     public int inputBridgeLength() {
         InputView inputView = new InputView();
         String length = inputView.readBridgeSize();
-        inputView.validateEmptyInput(length);
-        inputView.validateBridgeLength();
+        while (!inputView.validateBridgeLength()) {
+            length = inputView.readBridgeSize();
+        }
         return inputView.convertInput(length);
     }
 

--- a/src/main/java/bridge/service/BridgeGame.java
+++ b/src/main/java/bridge/service/BridgeGame.java
@@ -30,7 +30,7 @@ public class BridgeGame {
     public void startRound() {
         gameResult = true;
         playRound();
-        round.printFinalResult(trial);
+        round.printFinalResult(trial, round.quitRound);
     }
 
     public void playRound() {

--- a/src/main/java/bridge/service/Round.java
+++ b/src/main/java/bridge/service/Round.java
@@ -14,6 +14,7 @@ public class Round {
     private List<List<String>> roundResult;
     RoundJudge roundJudge;
     InputView inputView;
+    boolean quitRound = false;
 
     public Round(List<String> answerBridge) {
         this.answerBridge = answerBridge;
@@ -50,8 +51,11 @@ public class Round {
         OutputView.printMap(roundResult);
     }
 
-    public void printFinalResult(long trial) {
+    public void printFinalResult(long trial, boolean quitRound) {
         String result = gameResult(roundJudge.isUserBridgeCorrect());
+        if (!quitRound) {
+            OutputView.printEmptyLine();
+        }
         OutputView.printResult(roundResult, result, trial);
     }
 
@@ -67,6 +71,10 @@ public class Round {
     }
 
     public boolean retryRound() {
-        return roundJudge.judgeRetryRound();
+        if (roundJudge.judgeRetryRound()) {
+            return true;
+        }
+        quitRound = true;
+        return false;
     }
 }

--- a/src/main/java/bridge/service/Round.java
+++ b/src/main/java/bridge/service/Round.java
@@ -23,10 +23,12 @@ public class Round {
     }
 
     public String inputCommand() {
-        String command = inputView.readMoving();
-        inputView.validateEmptyInput(command);
-        inputView.validateGameCommand();
-        return command;
+        String move = inputView.readMoving();
+        while (!inputView.validateMoveCommand()) {
+            move = inputView.readMoving();
+        }
+        inputView.validateMoveCommand();
+        return move;
     }
 
     public boolean compareBridgeSize() {

--- a/src/main/java/bridge/service/Round.java
+++ b/src/main/java/bridge/service/Round.java
@@ -57,6 +57,7 @@ public class Round {
             OutputView.printEmptyLine();
         }
         OutputView.printResult(roundResult, result, trial);
+
     }
 
     public boolean isCorrectRound() {

--- a/src/main/java/bridge/service/RoundJudge.java
+++ b/src/main/java/bridge/service/RoundJudge.java
@@ -30,8 +30,9 @@ public class RoundJudge {
 
     public boolean judgeRetryRound() {
         String command = inputView.readGameCommand();
-        inputView.validateEmptyInput(command);
-        inputView.validateRetryCommand();
+        while (!inputView.validateRetryCommand()) {
+            command = inputView.readGameCommand();
+        }
         return command.equals(GameCommand.RETRY.getCommand());
     }
 

--- a/src/main/java/bridge/util/InputView.java
+++ b/src/main/java/bridge/util/InputView.java
@@ -15,20 +15,16 @@ public class InputView {
         inputValidation = new Validation();
     }
 
-    public void validateBridgeLength() {
-        inputValidation.validateBridgeLength(bridgeLength);
+    public boolean validateBridgeLength() {
+        return inputValidation.validateBridgeLength(bridgeLength);
     }
 
-    public void validateGameCommand() {
-        inputValidation.validateGameCommand(command);
+    public boolean validateMoveCommand() {
+        return inputValidation.validateMoveCommand(command);
     }
 
-    public void validateRetryCommand() {
-        inputValidation.validateRetryCommand(retry);
-    }
-
-    public void validateEmptyInput(String input) {
-        inputValidation.validateEmptyInput(input);
+    public boolean validateRetryCommand() {
+        return inputValidation.validateRetryCommand(retry);
     }
 
     public String readBridgeSize() {

--- a/src/main/java/bridge/util/OutputView.java
+++ b/src/main/java/bridge/util/OutputView.java
@@ -18,13 +18,12 @@ public class OutputView {
     }
 
     public static void printResult(List<List<String>> resultBridge, String gameResult, long trial) {
-        Validation validation = new Validation();
-        validation.isValidTrialNumber(trial);
         printSystemMessage(Messages.GAME_RESULT_TITLE);
         printMap(resultBridge);
         printGameResultMessage(Messages.GAME_RESULT_MESSAGE, gameResult);
         printGameTrialMessage(Messages.GAME_TRIAL_MESSAGE, trial);
     }
+
 
     public static void printSystemMessage(Messages messages) {
         System.out.println(messages.getMessage());

--- a/src/main/java/bridge/util/OutputView.java
+++ b/src/main/java/bridge/util/OutputView.java
@@ -15,7 +15,7 @@ public class OutputView {
 
     public static void printResult(List<List<String>> resultBridge, String gameResult, long trial) {
         Validation validation = new Validation();
-        validation.validateTrialNumber(trial);
+        validation.isValidTrialNumber(trial);
         printSystemMessage(Messages.GAME_RESULT_TITLE);
         printMap(resultBridge);
         printGameResultMessage(Messages.GAME_RESULT_MESSAGE, gameResult);

--- a/src/main/java/bridge/util/OutputView.java
+++ b/src/main/java/bridge/util/OutputView.java
@@ -13,6 +13,10 @@ public class OutputView {
         System.out.println(bridgeFormat.formattedBridge());
     }
 
+    public static void printEmptyLine() {
+        System.out.println();
+    }
+
     public static void printResult(List<List<String>> resultBridge, String gameResult, long trial) {
         Validation validation = new Validation();
         validation.isValidTrialNumber(trial);

--- a/src/main/java/bridge/validation/Validation.java
+++ b/src/main/java/bridge/validation/Validation.java
@@ -75,11 +75,4 @@ public class Validation {
         return true;
     }
 
-    public boolean isValidTrialNumber(long trial) {
-        if (trial > Integer.MAX_VALUE) {
-            System.out.println(errorHead + ERROR_EXCESS_MAXIMUM_TRIAL.getError());
-            return false;
-        }
-        return true;
-    }
 }

--- a/src/main/java/bridge/validation/Validation.java
+++ b/src/main/java/bridge/validation/Validation.java
@@ -9,53 +9,77 @@ public class Validation {
 
     private final String errorHead = ERROR_HEAD.getError();
 
-    public void validateBridgeLength(String input) {
-        validateLengthDigit(input);
-        validateLengthInteger(input);
-        validateLengthRange(Integer.parseInt(input));
+    public boolean validateBridgeLength(String input) {
+        return validateLengthDigit(input) && isValidLengthType(input)
+                && isValidLengthRange(Integer.parseInt(input)) && isInputEmpty(input);
     }
 
-    private void validateLengthDigit(String input) {
+    public boolean validateMoveCommand(String input) {
+        return isValidMoveCommand(input) && isInputEmpty(input);
+    }
+
+    public boolean validateRetryCommand(String input) {
+        if (isValidRetryCommand(input) && isInputEmpty(input)) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean validateLengthDigit(String input) {
         if (!input.matches("[0-9]+")) {
-            throw new IllegalArgumentException(errorHead + ERROR_NON_DIGIT.getError());
+            System.out.println(errorHead + ERROR_NON_DIGIT.getError());
+            return false;
         }
+        return true;
     }
 
-    public void validateEmptyInput(String input) {
+    public boolean isInputEmpty(String input) {
         if (input.equals("")) {
-            throw new IllegalArgumentException(errorHead + ERROR_EMPTY_INPUT.getError());
+            System.out.println(errorHead + ERROR_EMPTY_INPUT.getError());
+            return false;
         }
+        return true;
     }
 
-    private void validateLengthRange(int convertedInput) {
+    private boolean isValidLengthRange(int convertedInput) {
         if (convertedInput < Bridge.START_OF_RANGE.getRange() || Bridge.END_OF_RANGE.getRange() < convertedInput) {
-            throw new IllegalArgumentException(errorHead + ERROR_INVALID_BRIDGE_LENGTH.getError());
+            System.out.println(errorHead + ERROR_INVALID_BRIDGE_LENGTH.getError());
+            return false;
         }
+        return true;
     }
 
-    private void validateLengthInteger(String input) {
+    private boolean isValidLengthType(String input) {
         if (Long.parseLong(input) > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException(errorHead + ERROR_EXCESS_INTEGER.getError());
+            System.out.println(errorHead + ERROR_EXCESS_INTEGER.getError());
+            return false;
         }
+        return true;
     }
 
-    public void validateGameCommand(String gameCommandInput) {
+    public boolean isValidMoveCommand(String gameCommandInput) {
         if (!gameCommandInput.equals(GameCommand.UP.getCommand()) &&
                 !gameCommandInput.equals(GameCommand.DOWN.getCommand())) {
-            throw new IllegalArgumentException(errorHead + ERROR_INVALID_GAME_COMMAND.getError());
+            System.out.println(errorHead + ERROR_INVALID_GAME_COMMAND.getError());
+            return false;
         }
+        return true;
     }
 
-    public void validateRetryCommand(String gameCommandInput) {
+    public boolean isValidRetryCommand(String gameCommandInput) {
         if (!gameCommandInput.equals(GameCommand.RETRY.getCommand()) &&
                 !gameCommandInput.equals(GameCommand.QUIT.getCommand())) {
-            throw new IllegalArgumentException(errorHead + ERROR_INVALID_REPLAY_COMMAND.getError());
+            System.out.println(errorHead + ERROR_INVALID_REPLAY_COMMAND.getError());
+            return false;
         }
+        return true;
     }
 
-    public void validateTrialNumber(long trial) {
+    public boolean isValidTrialNumber(long trial) {
         if (trial > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException(errorHead + ERROR_EXCESS_MAXIMUM_TRIAL.getError());
+            System.out.println(errorHead + ERROR_EXCESS_MAXIMUM_TRIAL.getError());
+            return false;
         }
+        return true;
     }
 }

--- a/src/main/java/bridge/view/Messages.java
+++ b/src/main/java/bridge/view/Messages.java
@@ -6,7 +6,7 @@ public enum Messages {
     INPUT_BRIDGE_LENGTH_MESSAGE("\n다리의 길이를 입력해주세요."),
     INPUT_GAME_COMMAND_MESSAGE("\n이동할 칸을 선택해주세요. (위: U, 아래: D)"),
     GAME_RETRY_MESSAGE("\n게임을 다시 시도할지 여부를 입력해주세요. (재시도: R, 종료: Q)"),
-    GAME_RESULT_TITLE("\n최종 게임 결과"),
+    GAME_RESULT_TITLE("최종 게임 결과"),
     GAME_RESULT_MESSAGE("\n게임 성공 여부: %s"),
     GAME_TRIAL_MESSAGE("총 시도한 횟수: %s");
 

--- a/src/test/java/bridge/UI/InputTest.java
+++ b/src/test/java/bridge/UI/InputTest.java
@@ -60,7 +60,7 @@ public class InputTest extends NsTest {
         @ValueSource(strings = {"1", "QQ", "RR", " "})
         void retryCommandTest(String input) {
             assertRandomNumberInRangeTest(() -> {
-                run("3", "U", "U" ,"U", input);
+                runException("3", "U", "U" ,"U", input);
                 assertThat(output()).contains(Errors.ERROR_INVALID_REPLAY_COMMAND.getError());
             }, 1, 1, 0);
         }


### PR DESCRIPTION
## 💡 Motivation
- 다리길이, 게임 움직임 명령어, 재시도 명령어가 유효하지 않을시 어플리케이션 종료하던 오류 수정
- 게임 실패 후 재시도 안할시 공백 한줄 더 출력되던 오류 수정


<br>

## 🔑 Key Changes
- `BridgeMaker`, `Round`, `RoundJudge` : 입력값을 최초 한번 받고 검증 메소드에서 `true` 를 받을때까지 입력 받도록 변경
- `OutputView`
    - 게임 실패 후 종료 했을때 공백 한줄 출력되던 오류 수정
    - 공백 한줄만 출력하는 메소드 추가
- `Round` : 게임 재시도 취소 상태를 기록하는 변수 추가
- `Message` : 게임 최종 결과 상수에서 이스케이프 문자 삭제
- `InputTest` : 검증메소드 변경
- `Application` : `try-catch` 문을 삭제해서 어플리케이션 종료하지 않도록 변경

<br>

## 🗒️ Todo
- 🥲
- 🧗‍♀️
- 🛫


<br>
